### PR TITLE
Enable other libraries to integrate Consumer through SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "Consumer"
+    name: "Consumer",
+    products: [
+        .library(name: "Consumer", targets: ["Consumer"])
+    ],
+    targets: [
+        .target(name: "Consumer", path: "Sources")
+    ]
 )

--- a/Sources/Consumer.swift
+++ b/Sources/Consumer.swift
@@ -76,7 +76,7 @@ public extension Consumer {
     }
 
     /// Abstract syntax tree returned by consumer
-    indirect enum Match: Equatable {
+    public indirect enum Match: Equatable {
         case token(String, Location)
         case node(Label?, [Match])
 
@@ -84,7 +84,7 @@ public extension Consumer {
         public var location: Location? { return _location }
 
         /// Transform generic AST to application-specific form
-        func transform(_ fn: Transform) rethrows -> Any? {
+        public func transform(_ fn: Transform) rethrows -> Any? {
             return try _transform(fn)
         }
     }
@@ -96,7 +96,7 @@ public extension Consumer {
     }
 
     /// Closure for transforming a Match to an application-specific data type
-    typealias Transform = (_ name: Label, _ values: [Any]) throws -> Any?
+    public typealias Transform = (_ name: Label, _ values: [Any]) throws -> Any?
 
     /// A Parsing error
     struct Error: Swift.Error {


### PR DESCRIPTION
👋 Nick. I thought I'd try and build a Gherkin parser using Consumer but ran into the lack of targets in `Package.swift`.

**Steps to reproduce:** `swift build` fails on master & is fixed with this commit.

**Swift Test**
PerformanceTests.swift uses the json parsing methods from the examples which SPM is not aware of. We can add two folders ConsumerTests & ConsumerExampleTests. Adding `.testTarget(name: "ConsumerTests")` should get swift test to work (if it's worth the overhead of maintaining).
